### PR TITLE
Change replaceAll function to an alternative that is compatible with older browsers

### DIFF
--- a/src/body_components/blog.js
+++ b/src/body_components/blog.js
@@ -8,7 +8,6 @@ function Blog() {
     const [blogPostTitles, setBlogPostTitles] = React.useState([]);
 
     React.useEffect(() => {
-        let isMounted = true;
         fetchBlogTitles(setBlogPostTitles)
     }, []);
 
@@ -29,7 +28,7 @@ function Blog() {
 }
 
 function userReadableTitle(originalTitle) {
-    return originalTitle.replaceAll("_", " ");
+    return originalTitle.replace(/_/g, " ");
 }
 
 async function fetchBlogTitles(setter) {


### PR DESCRIPTION
CloudFlare is using an outdated browser in deployments. Therefore, the `replaceAll()` method breaks the tests. Changing this to `replace()` with a global regex string is more broadly compatible with browsers and fixes the tests.